### PR TITLE
Hook up the new parser to a NIF.

### DIFF
--- a/native/fast_json/src/lib.in.rs
+++ b/native/fast_json/src/lib.in.rs
@@ -11,12 +11,13 @@ use rustler::atom::init_atom;
 mod encoder;
 mod decoder;
 mod parser;
+mod new_decoder;
 
 rustler_export_nifs! {
     "Elixir.Json",
     [("native_parse", 2, decoder::decode),
      ("stringify", 2, encoder::encode),
-     ("parse", 2, parser::parse)],
+     ("parse", 2, new_decoder::new_decode)],
     Some(load)
 }
 

--- a/native/fast_json/src/new_decoder.rs
+++ b/native/fast_json/src/new_decoder.rs
@@ -1,0 +1,21 @@
+use std::error::Error;
+use super::parser;
+use rustler::{NifDecoder, NifEncoder, NifEnv, NifTerm, NifResult};
+use rustler::tuple::make_tuple;
+use rustler::atom::get_atom;
+
+pub fn new_decode<'a>(env: &'a NifEnv, args: &Vec<NifTerm>) -> NifResult<NifTerm<'a>> {
+    let data = <String as NifDecoder>::decode(args[0])?;
+
+    match parser::parse(env, data) {
+        Ok(term) => {
+            let ok = get_atom("ok").unwrap().to_term(env);
+            Ok(make_tuple(env, &[ok, term]))
+        }
+        Err(err) =>  {
+            let error = get_atom("error").unwrap().to_term(env);
+            let message = err.description().encode(env);
+            Ok(make_tuple(env, &[error, message]))
+        }
+    }
+}


### PR DESCRIPTION
This commit does three things:

1. put the error-chain stuff back, so `parser::errors::Error` is a custom error type

2. fix some borrow checker errors I had in there

3. write a new NIF to call the hand-rolled parser and cope with errors.